### PR TITLE
Fix/only run tests once mysql ready

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,12 +59,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Docker build
+      - name: Run tests
         run: |
-          docker build -t 2fa_test_main tests/
-      - name: Docker start database 
-        run: |
-          docker run -d --name=2fa_test_mysql -e MYSQL_DATABASE=2fa_test -e MYSQL_ROOT_PASSWORD=foobar mysql:5.7
-      - name: Docker run tests
-        run: |
-          docker run --rm -v `pwd`:/app --link=2fa_test_mysql -e MYSQL_HOST=2fa_test_mysql -e MYSQL_PASSWORD=foobar 2fa_test_main sh -c 'bundle install && bundle exec rspec spec/*_spec.rb'
+          tests/run-with-docker.sh

--- a/tests/run-with-docker.sh
+++ b/tests/run-with-docker.sh
@@ -18,4 +18,4 @@ while  STATUS=`docker inspect --format "{{.State.Health.Status}}" 2fa_test_mysql
 done
 
 # Run the tests
-docker run -ti --rm -v `pwd`:/app -e MYSQL_HOST=${HOST} -e MYSQL_PASSWORD=foobar 2fa_test_main sh -c 'bundle install && bundle exec rspec spec/*_spec.rb'
+docker run --rm -v `pwd`:/app -e MYSQL_HOST=${HOST} -e MYSQL_PASSWORD=foobar 2fa_test_main sh -c 'bundle install && bundle exec rspec spec/*_spec.rb'

--- a/tests/run-with-docker.sh
+++ b/tests/run-with-docker.sh
@@ -10,8 +10,12 @@ docker build -t 2fa_test_main tests/
 # Get MySQL running
 docker stop 2fa_test_mysql || true
 docker rm 2fa_test_mysql || true
-docker run -d --name=2fa_test_mysql -e MYSQL_DATABASE=2fa_test -e MYSQL_ROOT_PASSWORD=foobar mysql:5.7
+docker run -d --name=2fa_test_mysql --health-cmd='mysqladmin ping --silent' -e MYSQL_DATABASE=2fa_test -e MYSQL_ROOT_PASSWORD=foobar mysql:5.7
 export HOST=`docker inspect -f '{{.NetworkSettings.IPAddress}}' 2fa_test_mysql`
+while  STATUS=`docker inspect --format "{{.State.Health.Status}}" 2fa_test_mysql`; [ $STATUS != "healthy" ]; do
+    echo "waiting for database"
+    sleep 1
+done
 
 # Run the tests
 docker run -ti --rm -v `pwd`:/app -e MYSQL_HOST=${HOST} -e MYSQL_PASSWORD=foobar 2fa_test_main sh -c 'bundle install && bundle exec rspec spec/*_spec.rb'


### PR DESCRIPTION
This PR:

1. Fixes a race condition which meant the integration tests would sometimes start running before the db container was ready
1. Updates the CI integration tests to use the same script we use to run them locally, for consistency and ease of maintenance