### PR TITLE
Inject scripts into the head after its creation

### DIFF
--- a/lib/login.php
+++ b/lib/login.php
@@ -65,11 +65,11 @@ $render = function ($phase, $errors, $rememberme, $user_id) use ($get_redirect_t
 
     $redirect_to = $get_redirect_to($user);
 
-    do_action('login_enqueue_scripts');
-    do_action('login_head');
-
     $errors = apply_filters('wp_login_errors', $errors, $redirect_to);
     login_header(__('Log In'), '', $errors);
+
+    do_action('login_enqueue_scripts');
+    do_action('login_head');
 
     if ($first_phase) {
         // Phase 1 - user/pass form?>


### PR DESCRIPTION
## Description

Before, login scripts were inserted into the page before the header had been generated, leading to certain meta tags and links being placed outside of the head in the HTML document.

To address the problem that resulted in invalid HTML documents, actions related to the head are now triggered following the execution of login_header.

Related Trello card: https://trello.com/c/f7Qiwcj8/28-investigate-unusual-doctype-placement-on-admin-login-page

## Screenshots
**Before:**
![image](https://github.com/dxw/2fa/assets/53922624/f0b288eb-654a-4185-845d-038bd099b843)

**After:**
![image](https://github.com/dxw/2fa/assets/53922624/99b880ef-4006-4dfc-b4a4-10fd2e618b33)


## How to Test
1. Ensure 2FA is activated in the project you are testing
1. [Access the login page](http://localhost/wp-login.php)
2. View the source code
3. Confirm there are no `<meta>` or `<link>` tags misplaced
4. Make sure the `wp-login page` is functioning as expected