### PR TITLE
Fix/twilio checks

### DIFF
--- a/2fa.php
+++ b/2fa.php
@@ -6,7 +6,7 @@ Description: Enables 2 factor authentication
 Author: dxw
 Author URI: http://dxw.com
 Network: true
-Version: 2.0.2
+Version: 2.0.3
 */
 
 $registrar = require __DIR__.'/src/load.php';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.3] - 2024-12-19
+
+### Changed
+
+- Allow disabling of Twilio SMS 2FA (via TWILIO_DISABLED constant)
+
 ## [v2.0.2] - 2024-12-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ WordPress plugin for 2 factor authentication (TOTP and SMS)
 
 At the moment this plugin must be installed on a multisite installation.
 
-If you don't have a Twilio account, there's currently no way to hide SMS from the setup page.
-
 To enable SMS authentication add these constants to your wp-config.php:
 
     define('TWILIO_ACCOUNT_SID', 'AC...');
@@ -15,6 +13,8 @@ To enable SMS authentication add these constants to your wp-config.php:
     define('TWILIO_NUMBER', '...');
 
 You can find those [here](https://www.twilio.com/user/account/voice-sms-mms/getting-started).
+
+If there is no Twilio account setup for SMS authentication or it needs to be disabled, add a constant `TWILIO_DISABLED`
 
 ## Usage
 

--- a/views/setup.php
+++ b/views/setup.php
@@ -57,6 +57,7 @@ if (!twofa_user_enabled(get_current_user_id())) {
               </div>
             </div>
           </li>
+          <?php if (!defined('TWILIO_DISABLED')): ?>
           <li>
             <label>
               <input type="radio" name="2fa_setup_device" value="sms" ng-model="$root.mode">
@@ -67,6 +68,7 @@ if (!twofa_user_enabled(get_current_user_id())) {
               <p>Give your mobile a name that you can later use to identify it: <input type="text" ng-model="$root.device_name"></p>
             </div>
           </li>
+          <?php endif; ?>
           <li>
             <label>
               <input type="radio" name="2fa_setup_device" value="email" ng-model="$root.mode">


### PR DESCRIPTION
## Description

Adds an option to disable Twilio for SMS 2FA    
- Using a TWILIO_DISABLED constant
- To cater for essex-blogs discontinued twilio account (https://dxw.zendesk.com/agent/tickets/20492) 

(Will need rebase)

## Test
config/server.php:
`define('TWILIO_DISABLED','Twilio account not set up');`