### PR TITLE
Feature/2fa options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Allow disabling of Twilio SMS 2FA (via TWILIO_DISABLED constant)
+- Allow selective disabling 2FA options (via wp-config constants)
 
 ## [v2.0.2] - 2024-12-19
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can find those [here](https://www.twilio.com/user/account/voice-sms-mms/gett
 
 To disable 2FA options from being selectable, add constants as follows:
 * `2FA_SMS_DISABLED` to disable SMS (for example if no Twilio account is setup)
-
+* `2FA_SMART_DEVICE_DISABLED` to disable smartphone or tablet option
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ To enable SMS authentication add these constants to your wp-config.php:
 
 You can find those [here](https://www.twilio.com/user/account/voice-sms-mms/getting-started).
 
-If there is no Twilio account setup for SMS authentication or it needs to be disabled, add a constant `TWILIO_DISABLED`
+To disable 2FA options from being selectable, add constants as follows:
+* `2FA_SMS_DISABLED` to disable SMS (for example if no Twilio account is setup)
+
 
 ## Usage
 

--- a/views/setup.php
+++ b/views/setup.php
@@ -57,7 +57,7 @@ if (!twofa_user_enabled(get_current_user_id())) {
               </div>
             </div>
           </li>
-          <?php if (!defined('TWILIO_DISABLED')): ?>
+          <?php if (!defined('2FA_SMS_DISABLED')): ?>
           <li>
             <label>
               <input type="radio" name="2fa_setup_device" value="sms" ng-model="$root.mode">

--- a/views/setup.php
+++ b/views/setup.php
@@ -38,6 +38,7 @@ if (!twofa_user_enabled(get_current_user_id())) {
         <p>What kind of device are you using?</p>
 
         <ul>
+        <?php if (!defined('2FA_SMART_DEVICE_DISABLED')): ?>
           <li>
             <div>
               <label>
@@ -57,6 +58,7 @@ if (!twofa_user_enabled(get_current_user_id())) {
               </div>
             </div>
           </li>
+          <?php endif; ?>
           <?php if (!defined('2FA_SMS_DISABLED')): ?>
           <li>
             <label>

--- a/views/setup.php
+++ b/views/setup.php
@@ -35,7 +35,7 @@ if (!twofa_user_enabled(get_current_user_id())) {
       <?php # STEP 1?>
 
       <div ng-switch-when="start" class="step">
-        <p>What kind of device are you using?</p>
+        <p>What kind of device or 2FA option are you using?</p>
 
         <ul>
         <?php if (!defined('2FA_SMART_DEVICE_DISABLED')): ?>
@@ -74,7 +74,11 @@ if (!twofa_user_enabled(get_current_user_id())) {
           <li>
             <label>
               <input type="radio" name="2fa_setup_device" value="email" ng-model="$root.mode">
-              I don't have a phone I can use at work.
+              <?php if (defined('2FA_SMART_DEVICE_DISABLED') && defined('2FA_SMS_DISABLED')) : ?>
+                email
+              <?php else: ?>
+                I don't have a phone I can use at work.
+              <?php endif; ?>
             </label>
             <div ng-show="$root.mode === 'email'">
               <p>The activation code email will be sent to this email address: <strong><?php echo esc_html(wp_get_current_user()->user_email) ?></strong></p>


### PR DESCRIPTION
Adds options to selectively disable 2FA options for setup

To cater for essex-blogs only wanting email (https://dxw.zendesk.com/agent/tickets/20492)
Builds on https://github.com/dxw/2fa/pull/79

Test
config/server.php:
define('2FA_SMS_DISABLED','Twilio account not set up');
define('2FA_SMART_DEVICE_DISABLED','Not desired for this site');

