### PR TITLE
Avoid fatal errors by checking POST validity

### DIFF
--- a/lib/login.php
+++ b/lib/login.php
@@ -3,7 +3,7 @@
 // Gets the filtered value of the redirect_to parameter (string)
 // Taken from wp-login.php
 $get_redirect_to = function ($user) {
-	if (isset($_REQUEST['redirect_to'])) {
+	if (isset($_REQUEST['redirect_to']) && is_string($_REQUEST['redirect_to'])) {
 		$redirect_to = $_REQUEST['redirect_to'];
 		// // Redirect to https if user wants ssl
 		// if ( $secure_cookie && false !== strpos($redirect_to, 'wp-admin') ) { //
@@ -13,7 +13,7 @@ $get_redirect_to = function ($user) {
 		$redirect_to = admin_url();
 	}
 
-	$requested_redirect_to = isset($_REQUEST['redirect_to']) ? $_REQUEST['redirect_to'] : '';
+	$requested_redirect_to = (isset($_REQUEST['redirect_to']) && is_string($_REQUEST['redirect_to'])) ? $_REQUEST['redirect_to'] : '';
 	return apply_filters('login_redirect', $redirect_to, $requested_redirect_to, $user);
 };
 

--- a/lib/login.php
+++ b/lib/login.php
@@ -163,7 +163,7 @@ add_action('login_form_login', function () use ($redirect, $render) {
 
 	// Phase 1
 
-	if (isset($_POST['log']) && isset($_POST['pwd'])) {
+	if (isset($_POST['log']) && is_string($_POST['log']) && isset($_POST['pwd']) && is_string($_POST['pwd'])) {
 		// Verify credentials
 		$user = wp_authenticate($_POST['log'], $_POST['pwd']);
 
@@ -191,7 +191,9 @@ add_action('login_form_login', function () use ($redirect, $render) {
 
 	// Phase 2
 
-	if (isset($_POST['token']) && isset($_POST['user_id']) && isset($_POST['nonce'])) {
+	if (isset($_POST['token']) && is_string($_POST['token']) &&
+		isset($_POST['user_id']) && is_string($_POST['user_id']) &&
+		isset($_POST['nonce']) && is_string($_POST['nonce'])) {
 		$user_id = absint($_POST['user_id']);
 
 		if ($user_id <= 0) {
@@ -201,7 +203,8 @@ add_action('login_form_login', function () use ($redirect, $render) {
 
 		if (twofa_bruteforce_login_show_captcha($user_id)) {
 			$recaptcha = new \ReCaptcha\ReCaptcha(RECAPTCHA_PRIVATE_KEY);
-			$resp = $recaptcha->verify(stripslashes($_POST['g-recaptcha-response']), $_SERVER['REMOTE_ADDR']);
+			$g_recaptcha_response = (isset($_POST['g-recaptcha-response']) && is_string($_POST['g-recaptcha-response'])) ? $_POST['g-recaptcha-response'] : '';
+			$resp = $recaptcha->verify(stripslashes($g_recaptcha_response), $_SERVER['REMOTE_ADDR']);
 			if (!$resp->isSuccess()) {
 				$errors->add('invalid_captcha', __('Invalid CAPTCHA. Try again.'));
 				$render(2, $errors, null, $user_id);


### PR DESCRIPTION
An attacker is currently attempting to find vulnerabilites on our sites.

Fatal errors are being generated via 2fa via `wp-login.php`

```
PHP Fatal error:  Uncaught TypeError: trim(): Argument #1 ($string) must be of type string, array given in /var/www/html/wp-includes/pluggable.php:686
 Stack trace:
 #0 /var/www/html/wp-includes/pluggable.php(686): trim()
 #1 /var/www/html/wp-content/plugins/2fa/lib/login.php(168): wp_authenticate()
 #2 /var/www/html/wp-includes/class-wp-hook.php(341): {closure}()
 #3 /var/www/html/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters()
 #4 /var/www/html/wp-includes/plugin.php(522): WP_Hook->do_action()
 #5 /var/www/html/wp-login.php(571): do_action()
 #6 {main}
 thrown in /var/www/html/wp-includes/pluggable.php on line 686
```

This is happening because POST variables are being presented as arrays but processed using string-only functions.

We should be checking for strings before using user-supplied values like this.